### PR TITLE
Implement job system and persistence

### DIFF
--- a/gamemode/cl_init.lua
+++ b/gamemode/cl_init.lua
@@ -4,3 +4,35 @@ hook.Add("HUDPaint", "DrawCash", function()
     local cash = LocalPlayer():GetNWInt("cash", 0)
     draw.SimpleText("$"..cash, "Trebuchet24", 10, 10, color_white, TEXT_ALIGN_LEFT, TEXT_ALIGN_TOP)
 end)
+
+local function OpenJobMenu()
+    local frame = vgui.Create("DFrame")
+    frame:SetTitle("Select Job")
+    frame:SetSize(200, 100)
+    frame:Center()
+    frame:MakePopup()
+
+    local combo = vgui.Create("DComboBox", frame)
+    combo:Dock(FILL)
+    combo:SetValue("Choose a job")
+    for id, tbl in pairs(g_JOBS) do
+        combo:AddChoice(tbl.name, id)
+    end
+
+    local btn = vgui.Create("DButton", frame)
+    btn:Dock(BOTTOM)
+    btn:SetText("Select")
+    btn.DoClick = function()
+        local _, id = combo:GetSelected()
+        if id then
+            net.Start("change_job")
+            net.WriteString(id)
+            net.SendToServer()
+        end
+        frame:Close()
+    end
+end
+
+net.Receive("open_npc_menu", OpenJobMenu)
+
+concommand.Add("lrp_job", OpenJobMenu)

--- a/gamemode/entities/loner_rp_npc/init.lua
+++ b/gamemode/entities/loner_rp_npc/init.lua
@@ -1,1 +1,18 @@
--- Serverside NPC code placeholder
+AddCSLuaFile("cl_init.lua")
+AddCSLuaFile("shared.lua")
+include("shared.lua")
+
+function ENT:Initialize()
+    self:SetModel("models/Humans/Group01/female_01.mdl")
+    self:SetHullType(HULL_HUMAN)
+    self:SetUseType(SIMPLE_USE)
+    self:PhysicsInit(SOLID_BBOX)
+    self:SetSolid(SOLID_BBOX)
+end
+
+function ENT:AcceptInput(name, activator)
+    if name == "Use" and IsValid(activator) and activator:IsPlayer() then
+        net.Start("open_npc_menu")
+        net.Send(activator)
+    end
+end

--- a/gamemode/init.lua
+++ b/gamemode/init.lua
@@ -2,8 +2,52 @@ AddCSLuaFile("cl_init.lua")
 AddCSLuaFile("shared.lua")
 include("shared.lua")
 
+util.AddNetworkString("change_job")
+util.AddNetworkString("open_npc_menu")
+
+local function loadPlayerData(ply)
+    local path = "loner_rp/playerdata/" .. ply:SteamID64() .. ".json"
+    if file.Exists(path, "DATA") then
+        local tbl = util.JSONToTable(file.Read(path, "DATA")) or {}
+        ply:SetMoney(tbl.money or 500)
+        ply:SetJob(tbl.job or "citizen")
+    else
+        ply:SetMoney(500)
+        ply:SetJob("citizen")
+    end
+end
+
 function GM:PlayerInitialSpawn(ply)
-    ply:SetNWInt("cash", 500)
+    loadPlayerData(ply)
+end
+
+function GM:PlayerSpawn(ply)
+    local job = g_JOBS[ply:GetNWString("job", "citizen")] or g_JOBS.citizen
+    if job.model then
+        ply:SetModel(job.model)
+    end
+    ply:StripWeapons()
+    for _, w in ipairs(job.weapons or {}) do
+        ply:Give(w)
+    end
+end
+
+net.Receive("change_job", function(len, ply)
+    local job = net.ReadString()
+    if g_JOBS[job] then
+        ply:SetJob(job)
+        ply:Spawn()
+    end
+end)
+
+function GM:PlayerDisconnected(ply)
+    local path = "loner_rp/playerdata/" .. ply:SteamID64() .. ".json"
+    file.CreateDir("loner_rp/playerdata")
+    local data = {
+        money = ply:GetMoney(),
+        job = ply:GetNWString("job", "citizen")
+    }
+    file.Write(path, util.TableToJSON(data, true))
 end
 
 hook.Add("PlayerSay", "CheckBalance", function(ply, text)

--- a/gamemode/shared.lua
+++ b/gamemode/shared.lua
@@ -4,3 +4,38 @@ GM.Email = "N/A"
 GM.Website = "N/A"
 
 DeriveGamemode("sandbox")
+
+-- Job table defining the available jobs and their loadouts
+g_JOBS = {
+    citizen = {
+        name = "Citizen",
+        model = "models/player/Group01/male_07.mdl",
+        weapons = {}
+    },
+
+    police = {
+        name = "Police Officer",
+        model = "models/player/police.mdl",
+        weapons = {"weapon_pistol"}
+    }
+}
+
+local PLAYER = FindMetaTable("Player")
+
+function PLAYER:SetMoney(amount)
+    self:SetNWInt("cash", amount or 0)
+end
+
+function PLAYER:AddMoney(amount)
+    self:SetMoney(self:GetNWInt("cash", 0) + (amount or 0))
+end
+
+function PLAYER:GetMoney()
+    return self:GetNWInt("cash", 0)
+end
+
+function PLAYER:SetJob(id)
+    if not g_JOBS[id] then return end
+    self:SetNWString("job", id)
+end
+


### PR DESCRIPTION
## Summary
- define job table and player helper methods
- load/save player job and money
- spawn player with job model and weapons
- add net messages for job change and NPC menu
- create client job menu and console command
- implement NPC that opens job menu

## Testing
- `luac -p gamemode/shared.lua`
- `luac -p gamemode/init.lua`
- `luac -p gamemode/cl_init.lua`
- `luac -p gamemode/entities/loner_rp_npc/init.lua`
- `luac -p gamemode/entities/loner_rp_npc/cl_init.lua`
- `apt-get update` *(fails: 403 Forbidden from mise.jdx.dev)*
- `apt-get install -y lua5.3`


------
https://chatgpt.com/codex/tasks/task_e_6885042120488330b99562a4a250dc3a