### PR TITLE
Add job info to HUD

### DIFF
--- a/gamemode/cl_init.lua
+++ b/gamemode/cl_init.lua
@@ -1,8 +1,14 @@
 include("shared.lua")
 
 hook.Add("HUDPaint", "DrawCash", function()
-    local cash = LocalPlayer():GetNWInt("cash", 0)
-    draw.SimpleText("$"..cash, "Trebuchet24", 10, 10, color_white, TEXT_ALIGN_LEFT, TEXT_ALIGN_TOP)
+    local ply = LocalPlayer()
+    local cash = ply:GetNWInt("cash", 0)
+    draw.SimpleText("$" .. cash, "Trebuchet24", 10, 10, color_white, TEXT_ALIGN_LEFT, TEXT_ALIGN_TOP)
+
+    local jobId = ply:GetNWString("job", "citizen")
+    local jobTbl = g_JOBS[jobId]
+    local jobName = jobTbl and jobTbl.name or jobId
+    draw.SimpleText("Job: " .. jobName, "Trebuchet24", 10, 30, color_white, TEXT_ALIGN_LEFT, TEXT_ALIGN_TOP)
 end)
 
 local function OpenJobMenu()


### PR DESCRIPTION
## Summary
- show the player's job on the HUD below the money display

## Testing
- `apt-get update`
- `apt-get install -y poppler-utils`

------
https://chatgpt.com/codex/tasks/task_e_688519c77edc83308d24ea7663f6d18e